### PR TITLE
Switch to new IG oembed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import InstagramEmbed from 'react-instagram-embed';
 
 <InstagramEmbed
   url='https://instagr.am/p/Zw9o4/'
+  accessToken='123|456'
   maxWidth={320}
   hideCaption={false}
   containerTagName='div'
@@ -38,6 +39,7 @@ import InstagramEmbed from 'react-instagram-embed';
 ## props
 
 - `url` {String} Instagram URL. Required
+- `accessToken` {String} Instagram Client Access Token. Required
 - `maxWidth` {Number} Max width. Minimum size is `320`. Default `undefined`
 - `hideCaption` {Boolean} Default `false`
 - `containerTagName` {String} Default `'div'`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ declare global {
 
 export interface Props<T = 'div'> {
   url: string;
+  accessToken: string;
   hideCaption: boolean;
   containerTagName: T;
   protocol: string;
@@ -108,7 +109,7 @@ export default class InstagramEmbed extends React.PureComponent<Props, State> {
   };
 
   private fetchEmbed(queryParams: string): void {
-    this.request = this.createRequestPromise(`https://api.instagram.com/oembed/?${queryParams}`);
+    this.request = this.createRequestPromise(`https://graph.facebook.com/v8.0/instagram_oembed/?${queryParams}`);
 
     if (this.props.onLoading) {
       this.props.onLoading();
@@ -164,15 +165,18 @@ export default class InstagramEmbed extends React.PureComponent<Props, State> {
 
   private getQueryParams({
     url,
+    accessToken,
     hideCaption,
     maxWidth
   }: {
     url: string;
+    accessToken: string;
     hideCaption: boolean;
     maxWidth?: number;
   }): string {
     return qs.stringify({
       url,
+      access_token: accessToken,
       hidecaption: hideCaption,
       maxwidth: typeof maxWidth === 'number' && maxWidth >= 320 ? maxWidth : undefined,
       omitscript: true


### PR DESCRIPTION
Instagram oembed API is deprecating 2020-10-24.

New oembed API returns same response data.
However, new API requires access_token URL param.

Thus this is a breaking change.