### PR TITLE
Switch to the new Instagram oembed API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ import InstagramEmbed from 'react-instagram-embed';
 
 <InstagramEmbed
   url='https://instagr.am/p/Zw9o4/'
+  accessToken='123|456'
   maxWidth={320}
   hideCaption={false}
   containerTagName='div'
@@ -35,9 +36,12 @@ import InstagramEmbed from 'react-instagram-embed';
 />
 ```
 
+Access token is combination of App Id and Client Token. See https://developers.facebook.com/docs/instagram/oembed/#access-tokens for more details.
+
 ## props
 
 - `url` {String} Instagram URL. Required
+- `accessToken` {String} Instagram Client Access Token. Required
 - `maxWidth` {Number} Max width. Minimum size is `320`. Default `undefined`
 - `hideCaption` {Boolean} Default `false`
 - `containerTagName` {String} Default `'div'`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-instagram-embed",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-instagram-embed",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "React embedding Instagram posts component",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ declare global {
 
 export interface Props<T = 'div'> {
   url: string;
+  accessToken: string;
   hideCaption: boolean;
   containerTagName: T;
   protocol: string;
@@ -108,7 +109,7 @@ export default class InstagramEmbed extends React.PureComponent<Props, State> {
   };
 
   private fetchEmbed(queryParams: string): void {
-    this.request = this.createRequestPromise(`https://api.instagram.com/oembed/?${queryParams}`);
+    this.request = this.createRequestPromise(`https://graph.facebook.com/v8.0/instagram_oembed/?${queryParams}`);
 
     if (this.props.onLoading) {
       this.props.onLoading();
@@ -164,15 +165,18 @@ export default class InstagramEmbed extends React.PureComponent<Props, State> {
 
   private getQueryParams({
     url,
+    accessToken,
     hideCaption,
     maxWidth
   }: {
     url: string;
+    accessToken: string;
     hideCaption: boolean;
     maxWidth?: number;
   }): string {
     return qs.stringify({
       url,
+      access_token: accessToken,
       hidecaption: hideCaption,
       maxwidth: typeof maxWidth === 'number' && maxWidth >= 320 ? maxWidth : undefined,
       omitscript: true


### PR DESCRIPTION
Instagram oembed API is deprecating 2020-10-24.
https://developers.facebook.com/docs/instagram/oembed-legacy

New oembed API returns the same response data.
However, the new API requires `accessToken` URL param.

Thus this is a breaking change.